### PR TITLE
Upgrade pytest-mozwebqa plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ py==1.4.7
 pytest==2.2.3
 pytest-mozwebqa==0.8
 pytest-xdist==1.8
-rdflib==3.1.0
 selenium


### PR DESCRIPTION
This pull upgrades to pytest-mozwebqa 0.8, and also updates py/pytest/pytest-xdist dependencies.

After merging, we should do the following to any relevant Jenkins jobs:
- Use seconds instead of milliseconds for the timeout command line option
- Use -m instead of -k for specifying mark filters
- Enabling archiving of HTML reports (as these are now much smaller than before)
