### PR TITLE
Upgrade to pytest-mozwebqa 0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ UnittestZero
 execnet==1.0.9
 py==1.4.7
 pytest==2.2.3
-pytest-mozwebqa==0.8
+pytest-mozwebqa==0.10
 pytest-xdist==1.8
 selenium


### PR DESCRIPTION
I've tested, and this works:

(3e6c8ef79fef12fe)host-5-121:qmo-tests moco$ cat requirements.txt 
PyYAML==3.10
UnittestZero
execnet==1.0.9
py==1.4.7
pytest==2.2.3
pytest-mozwebqa==0.10
pytest-xdist==1.8
selenium

py.test --driver=firefox tests/test_docs.py --browsername=firefox --browserver=11 --baseurl=http://quality.mozilla.org --destructive

====================================================================== 2 failed, 1 passed, 1 skipped, 1 xfailed in 36.66 seconds =======================================================================

Login fail because the credentials for QMO (at least on prod) don't work.
