### PR TITLE
Skip the link check if the link is for IRC

### DIFF
--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -51,9 +51,10 @@ class TestCommunityPage:
             len(urls), 0, u'something went wrong. no links found.')
 
         for url in urls:
-            check_result = crawler.verify_status_code_is_ok(url)
-            if check_result is not True:
-                bad_urls.append(check_result)
+            if not 'irc://irc.mozilla.org' in url:
+                check_result = crawler.verify_status_code_is_ok(url)
+                if check_result is not True:
+                    bad_urls.append(check_result)
 
         Assert.equal(
             0, len(bad_urls),


### PR DESCRIPTION
Checking "irc://irc.mozilla.org/devmo" does not return any status whatsoever(hereby considering it to be broken) because that link needs to be opened with and appliation(ex: Mibbit), so the fix here would be to skip the check of the urls containing links to mozilla IRC
