### PR TITLE
Add 'Firefox OS QA' team to the list of teams

### DIFF
--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -15,7 +15,8 @@ TEAM_NAMES = [
     u'Web QA',
     u'Thunderbird',
     u'Services QA',
-    u'Mobile QA']
+    u'Mobile QA',
+    u'Firefox OS QA']
 
 
 class TestTeamsPage:


### PR DESCRIPTION
Firefox OS QA team has been added to the list: https://quality.mozilla.org/teams/
